### PR TITLE
add sound imports and error handling to TimerController

### DIFF
--- a/.parcelrc
+++ b/.parcelrc
@@ -1,0 +1,8 @@
+{
+    "extends": "@parcel/config-default",
+    "transformers": {
+        "*.{wav,mp3}": [
+            "@parcel/transformer-raw"
+        ]
+    }
+}

--- a/asset/javascript/TimeController.js
+++ b/asset/javascript/TimeController.js
@@ -1,3 +1,5 @@
+import tickTackSoundUrl from '../sound/tick-tack.wav';
+import stopSoundUrl from '../sound/stop.mp3';
 import './helper.js';
 import { TimerStatus } from './TimerStatus.js';
 import {
@@ -33,8 +35,15 @@ function TimerController(reference) {
     const DEFAULT_INTERVAL = 1000;
     const DEFAULT_SECONDS = 30;
 
-    const tickTackSound = new Audio('./asset/sound/tick-tack.wav');
-    const stopSound = new Audio('./asset/sound/stop.mp3');
+    const tickTackSound = new Audio(tickTackSoundUrl);
+    const stopSound = new Audio(stopSoundUrl);
+    tickTackSound.addEventListener('error', e => {
+        console.error('Erro ao carregar tick-tack.wav:', e);
+    });
+
+    stopSound.addEventListener('error', e => {
+        console.error('Erro ao carregar stop.mp3:', e);
+    });
 
     let lastTimerStatus = TimerStatus.STOPPED;
     let previousTimerValue = DEFAULT_SECONDS;
@@ -166,7 +175,6 @@ function TimerController(reference) {
             if (canStart) {
                 let seconds = getInputsValueAsSeconds();
                 seconds--;
-
                 if (seconds <= 10) {
                     lastTimerStatus = TimerStatus.COUNTDOWN;
                     playCountdownSound();


### PR DESCRIPTION
Por padrão, o Percel lida com roteamento do lado do cliente. Isso significa que se o servidor recebe uma requisição para um caminho que ele não reconhece como um arquivo estático específico (como tick-tack.wav neste caso, porque não foi explicitamente importado ou referenciado de uma forma que o Parcel rastreie inicialmente no JS), ele assume que é uma rota da sua SPA e serve o index.html principal. O navegador então recebe o HTML em vez do arquivo de áudio esperado.
Por isso o audio deve ser importado no inicio do arquivo.js.
Diagnosticando o problema na versão anterior: é possivel ver na aba Network do browser assim que a pagina abrir e clicar na requisição que possui o nome no arquivo de audio, na resposta dessa requisição você vai ver o servidor responde o index.html em vez de ser o conteudo do audio.