### PR TITLE
Separando responsabilidades de [Exibir/ocultar botões de fullscreen]

### DIFF
--- a/asset/javascript/TimeController.js
+++ b/asset/javascript/TimeController.js
@@ -53,6 +53,7 @@ function TimerController(reference) {
     function init() {
         bindInputs();
         bindButtons();
+        bindFullscreenEvents();
         setInputValues(DEFAULT_SECONDS);
     }
 
@@ -97,6 +98,10 @@ function TimerController(reference) {
             }
         });
     };
+
+    function bindFullscreenEvents() {
+        document.addEventListener('fullscreenchange', handleButtonFullscreenChange);
+    }
 
     function validateInput(input, maxValue) {
         let value = parseInt(input.value) || 0;
@@ -260,17 +265,26 @@ function TimerController(reference) {
         }
     }
 
-    function handleFullscreen() {
-        if (!document.fullscreenElement) {
+    function isInFullscreen() {
+        return !!document.fullscreenElement
+    }
+    
+    function handleButtonFullscreenChange() {
+        if (isInFullscreen()) {
             exitFullscreenButton.showElement();
             enterFullscreenButton.hideElement();
-
-            document.documentElement.requestFullscreen();
             return;
         }
 
         enterFullscreenButton.showElement();
         exitFullscreenButton.hideElement();
+    }
+
+    function handleFullscreen() {
+        if (!document.fullscreenElement) {
+            document.documentElement.requestFullscreen();
+            return;
+        }
 
         document.exitFullscreen();
     }


### PR DESCRIPTION
## Motivação
Antes desta mudança, sair do modo FullScreen usando a tecla ESC não atualizava corretamente o estado dos botões de interface.  
Agora o Timer responde corretamente tanto a interações manuais (botões) quanto a interações nativas do navegador (ESC ou sair do FullScreen).


## Descrição
- Refatoração da classe `TimerController` para organizar o controle de FullScreen.
- Implementação do controle correto de entrada e saída de FullScreen, tanto por botão quanto pela tecla ESC.
- Separação clara entre ações (`handleFullscreen`) e reações (`handleButtonFullscreenChange`) para FullScreen.
- Inclusão do binding `bindFullscreenEvents()` para capturar mudanças de FullScreen.
- Atualização do estado dos botões ao entrar ou sair do modo FullScreen.

## Como testar
1. Iniciar o Timer.
2. Entrar em FullScreen utilizando o botão.
3. Sair do FullScreen utilizando o botão **ou pressionando ESC**.
4. Confirmar que os botões de FullScreen aparecem/desaparecem corretamente.
5. Confirmar que o Timer continua funcionando normalmente.

## Observações
- Não foram alteradas APIs públicas.
- Não houve breaking changes.